### PR TITLE
propose a workaround if any libstdc++ problem

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,23 +4,28 @@ Cobaltians-CLI is a node.js command line to build Android and iOS Cobalt project
 
 More information on Cobalt can be found [here](http://cobaltians.com).
 
-## Cobaltians CLI Installation
+## Install
 
     npm install cobaltians -g
 
 Using the -g flag installs the package globally, so it can be used in any project. Use sudo if needed.
 
-## Create project from the command line
-
-3) Create your app from a sample
-
-Choose a name and a base sample to create your first app :
+## Create a project from a template
 
     cobaltians create myApp HelloWorld
 
 This will create a "myApp" folder and ask if you want to create the corresponding iOS and Android projects.
 
 Available samples are for example "HelloWorld" or "Catalog". Read more about them [here](https://github.com/cobaltians/cobalt/wiki/Samples-list).
+
+If you receive errors about libstdc++ ( e.g `GLIBCXX_3.4.20' not found ) , which are commonly experienced on Linux, you can fix this by upgrading to the latest libstdc++-4.9.
+
+
+``` sh
+sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+sudo apt-get update
+sudo apt-get install libstdc++-4.9-dev
+```
 
 You can open your projects with XCode for iOS and Android Studio for Android.
 


### PR DESCRIPTION
nodegit come with a known error on Linux, see https://github.com/nodegit/nodegit/blob/master/README.md#getting-started
maybe would be nice to help to fix it in readme file

```
Error [Error: /usr/lib/x86_64-linux-gnu/libstdc++.so.6: version `GLIBCXX_3.4.20' not found (required by /home/lionel/dev/nodejs/node-v5.1.1-linux-x64/lib/node_modules/cobaltians/node_modules/nodegit/build/Release/nodegit.node)]
```
